### PR TITLE
Fixed class collisions of _KeyHandlerRegisterer

### DIFF
--- a/rebullet/keyhandler.py
+++ b/rebullet/keyhandler.py
@@ -30,6 +30,8 @@ class _KeyHandlerRegisterer(type):
         result = super().__new__(metacls, name, bases, classdict)
         if not hasattr(result, "_key_handler"):
             setattr(result, "_key_handler", {})
+        else: #Create a copy of the _key_handler attribute to avoid inherited classes from changing parent.
+            setattr(result, "_key_handler", getattr(result,"_key_handler").copy())
         setattr(result, "handle_input", _KeyHandlerRegisterer.handle_input)
 
         for value in classdict.values():


### PR DESCRIPTION
Changed `_KeyHandlerRegisterer`:
 - Before: The `__new__` method would create the _key_handler only when it was missing. This would cause inheriting classes to be using the same dictionary. I noticed this when trying to use Check. It would call the method `CheckDepencies.toggleRow` instead of `Check.toggleRow `Which would in turn cause an error.

 - After: The `__new__`method will create an independent copy of the dictionary. This fixes the issue with inherited classes overwriting the parent dictionary.

I haven't really tested this thoroughly since I have no clue how to. It does fix the issues with Check though.
This is my first pull request hope it's up to standards.